### PR TITLE
adding Snapshot.RequestNodesByName

### DIFF
--- a/src/heap_snapshot.h
+++ b/src/heap_snapshot.h
@@ -15,6 +15,7 @@ namespace nodex {
       static NAN_GETTER(GetRoot);
       static NAN_METHOD(GetNode);
       static NAN_METHOD(GetNodeById);
+      static NAN_METHOD(RequestNodesByName);
       static NAN_METHOD(Delete);
       static NAN_METHOD(Serialize);
       static Nan::Persistent<v8::ObjectTemplate> snapshot_template_;


### PR DESCRIPTION
- allows filtering snapshot for nodes with specific name on C++ side
- this is much faster than traversing heap in JS and makes use of the
  fact that a sorted snapshot node id-hash exists
- tests were added to demonstrate how this could be used to find all
  Buffers in a snapshot
- instead of returning a list, a provided callback is invoked for each
  buffer in order to simplify and speed up the implementation
- tests account for changes to how v8 stores Buffers, i.e. as
  Uint8Arrays

PR here for reference .. hopefully we can work on upstreaming this soon
